### PR TITLE
Improve configurability for managed environments, e.g. Dockhand on TrueNAS CE

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ npm start
 | `DATABASE_URL` | Yes | PostgreSQL connection string |
 | `JWT_EXPIRES_IN` | No | Token expiry, default `24h` |
 | `CORS_ORIGIN` | No | Allowed origin for CORS, set to your domain in production |
+| `HTTP_PORT` | No | Host HTTP port for use in production, e.g. behind a reverse proxy |
 | `POSTGRES_USER` | No | PostgreSQL user (Docker Compose) |
 | `POSTGRES_PASSWORD` | No | PostgreSQL password (Docker Compose) |
 | `POSTGRES_DB` | No | PostgreSQL database name (Docker Compose) |
+| `POSTGRES_VOLUME` | No | PostgreSQL database persistent host path (Docker Compose) |
 
 ## Security
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   postgres:
     image: postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dopamind_dev}
       POSTGRES_DB: ${POSTGRES_DB:-dopamind}
     volumes:
-      - ${POSTGRES_VOLUME:-pgdata}:/var/lib/postgresql/data
+      - ${POSTGRES_VOLUME:-./pgdata}:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-dopamind}"]
       interval: 5s
@@ -64,6 +64,3 @@ services:
     depends_on:
       - frontend
       - backend
-
-volumes:
-  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
   nginx:
     image: nginx:alpine
     ports:
-      - "80:80"
+      - "${HTTP_PORT:-80}:80"
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dopamind_dev}
       POSTGRES_DB: ${POSTGRES_DB:-dopamind}
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - ${POSTGRES_VOLUME:-pgdata}:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-dopamind}"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - PORT=4000
       - CORS_ORIGIN=http://localhost:3000,http://localhost
       - NODE_TLS_REJECT_UNAUTHORIZED=0
-      - DATABASE_URL=${DATABASE_URL:-postgresql://dopamind:dopamind_dev@postgres:5432/dopamind}
+      - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-dopamind}:${POSTGRES_PASSWORD:-dopamind_dev}@postgres:5432/${POSTGRES_DB:-dopamind}}
       # Required secrets – must be set in a .env file or the environment before running docker compose.
       # Generate with: openssl rand -hex 32
       - JWT_SECRET=${JWT_SECRET:?JWT_SECRET is not set. Copy .env.example to .env and fill in the required values.}


### PR DESCRIPTION
With these two changes one can set the persistent Postgres volume to a bind mount on the TrueNAS host. Also port 80 needs to be replaced by a high port.

<img width="1608" height="819" alt="Bildschirmfoto 2026-03-14 um 17 10 46" src="https://github.com/user-attachments/assets/80a83a76-d370-4fbd-ac0c-8ed60c89b2c0" />

Fixes:

https://github.com/Elmontag/Dopamind/issues/44
https://github.com/Elmontag/Dopamind/issues/48